### PR TITLE
Add common documentation layouts

### DIFF
--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -1,5 +1,37 @@
-<img src="{{ .Destination | relURL }}"
-  {{- with .Text }} alt="{{ . }}"{{ end -}}
-  {{- with .Title }} title="{{ . }}"{{ end -}}
->
+{{- /*
+Renders the image based on the provided image path.
+
+The path can be provided in different ways:
+
+- From the `static` folder:
+  ![Image alt](img/icons/quote.svg)
+
+- From any folder inside the `content` directory:
+  ![Image alt](/docs/resources/books/ddd-design.png)
+
+- From the current page folder:
+  ![Image alt](ddd-design.png)
+
+By default, each image will be rendered with `lazy` loading.
+To change this, add `"loading=eager"` as follows:
+![Image alt](ddd-design.png "loading=eager")
+*/ -}}
+
+{{ $link := .Destination }}
+{{ $loading := "lazy" }}
+
+{{ if not (strings.HasPrefix $link "/") }}
+    {{ $cleanedLink := replaceRE "#.*$" "" $link }}
+    {{ with .Page.Resources.GetMatch $cleanedLink }}
+        {{ $link = .RelPermalink }}
+    {{ else }}
+        {{ $link = $link | relURL }}
+    {{ end }}
+{{ end }}
+
+{{ if (eq .Title "loading=eager") }}
+    {{ $loading = "eager" }}
+{{ end }}
+
+<img src="{{ $link }}" alt="{{ .Text }}" loading="{{ $loading }}"/>
 {{- /* Strip trailing newline. */ -}}

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -1,0 +1,25 @@
+{{- $link := .Destination }}
+{{- $isMailto := strings.HasPrefix $link "mailto:" -}}
+{{- $isAbsolute := strings.HasPrefix $link "http" -}}
+{{- $isSamePageAnchor := strings.HasPrefix $link "#" -}}
+
+{{- $skipNofollow := partial "theme/functions/whitelist-checker.html" $link -}}
+{{- $isExternalLink := partial "theme/functions/is-external-link.html" $link -}}
+
+{{- if or $isAbsolute $isSamePageAnchor -}}
+    {{- $link = $link | safeURL -}}
+{{- else if (not $isMailto) }}
+    {{- $link = partial "theme/functions/get-doc-link.html" (dict
+        "link" $link
+        "page" .Page
+    ) -}}
+{{- end -}}
+
+<a href="{{ $link }}"
+   {{ with .Title }} title="{{ . }}"{{ end }}
+   {{ if $isExternalLink }}
+   class="external-link"
+   target="_blank"
+   rel="noopener{{ if not $skipNofollow }} nofollow{{ end }}"
+   {{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* Strip trailing newline. */ -}}

--- a/layouts/_partials/theme/docs/components/bottom-nav/functions/get-page.html
+++ b/layouts/_partials/theme/docs/components/bottom-nav/functions/get-page.html
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $page := .page_context }}
+{{ $item := .item_context }}
+
+{{ $currentVersion := partial "theme/functions/get-doc-version.html" $page }}
+{{ $filePath := printf "docs/%s/%s" $currentVersion.short $item.file_path }}
+{{ $pageURL := "" }}
+{{ $pageTitle := $item.page }}
+
+{{ with site.GetPage $filePath }}
+    {{ $pageURL = .RelPermalink }}
+{{ end }}
+
+{{ $pageItem := dict "url" $pageURL "title" $pageTitle }}
+
+{{ return $pageItem }}

--- a/layouts/_partials/theme/docs/components/bottom-nav/functions/get-pages.html
+++ b/layouts/_partials/theme/docs/components/bottom-nav/functions/get-pages.html
@@ -1,0 +1,68 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns the array of the sidenav pages and the index of the current page.
+-->
+
+{{ $root := .context }}
+{{ $sidenav := .sidenav }}
+{{ $currentURL := .current_url }}
+
+{{ $root.Scratch.Set "bottomNavPages" (slice) }}
+{{ $root.Scratch.Set "bottomNavCurrentIndex" -1 }}
+
+{{ range $sidenav }}
+    {{ template "get-bottom-nav-pages" (dict "root" $root "node" .) }}
+{{ end }}
+
+{{ define "get-bottom-nav-pages" }}
+    {{ $root := .root }}
+    {{ $node := .node }}
+    {{ with $node.children }}
+        {{ range . }}
+            {{ template "get-bottom-nav-pages" (dict "root" $root "node" .) }}
+        {{ end }}
+    {{ else }}
+        {{ if or $node.file_path (eq $node.file_path "") }}
+            {{ $page := partial "theme/docs/components/bottom-nav/functions/get-page.html" (dict
+                "page_context" $root
+                "item_context" $node
+            ) }}
+            {{ if $page.url }}
+                {{ $root.Scratch.Add "bottomNavPages" (slice $page) }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ $pages := $root.Scratch.Get "bottomNavPages" }}
+
+{{ range $i, $page := $pages }}
+    {{ if in $currentURL $page.url }}
+        {{ $root.Scratch.Set "bottomNavCurrentIndex" $i }}
+    {{ end }}
+{{ end }}

--- a/layouts/_partials/theme/docs/components/bottom-nav/next-prev-nav.html
+++ b/layouts/_partials/theme/docs/components/bottom-nav/next-prev-nav.html
@@ -1,0 +1,64 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $currentURL := .RelPermalink }}
+{{ $currentVersion := partial "theme/functions/get-doc-version.html" . }}
+{{ $versionData := index site.Data.docs $currentVersion.short }}
+
+{{ if $versionData }}
+    {{ $sidenav := $versionData.sidenav }}
+    {{ if $sidenav }}
+        {{ partial "theme/docs/components/bottom-nav/functions/get-pages" (dict
+            "context" .
+            "sidenav" $sidenav
+            "current_url" $currentURL
+        ) }}
+        {{ $pages := .Scratch.Get "bottomNavPages" }}
+        {{ $index := .Scratch.Get "bottomNavCurrentIndex" }}
+        <nav class="next-prev-nav" aria-label="Bottom navigation">
+            {{ if ge $index 1 }}
+                {{ $prev := index $pages (sub $index 1) }}
+                <div class="item previous">
+                    <a class="arrow-link prev"
+                       href="{{ $prev.url | relURL }}">
+                        <span>{{ $prev.title }}</span>
+                    </a>
+                </div>
+            {{ end }}
+            {{ if lt (add $index 1) (len $pages) }}
+                {{ $next := index $pages (add $index 1) }}
+                <div class="item next">
+                    <a class="arrow-link next"
+                       href="{{ $next.url | relURL }}">
+                        <span>{{ $next.title }}</span>
+                    </a>
+                </div>
+            {{ end }}
+        </nav>
+    {{ end }}
+    {{ .Scratch.Delete "bottomNavPages" }}
+    {{ .Scratch.Delete "bottomNavCurrentIndex" }}
+{{ end }}

--- a/layouts/_partials/theme/docs/components/sidenav/category.html
+++ b/layouts/_partials/theme/docs/components/sidenav/category.html
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $page := .page_context }}
+{{ $item := .item_context }}
+{{ $isActive := .is_active | default false }}
+
+{{ $currentCategory := partial "theme/functions/get-doc-category.html" $page }}
+{{ $categoryKey := $item.key }}
+{{ $id := print $categoryKey "-category" }}
+{{ $isActive = or (eq $currentCategory $categoryKey) $isActive }}
+
+<li>
+    <span class="sidenav-link tree-title {{ if not $isActive }}collapsed{{ end }}"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ $id }}"
+          aria-controls="{{ $id }}"
+          aria-expanded="{{ $isActive }}">
+        {{ $item.page }}
+    </span>
+    <ul id="{{ $id }}" class="subnav collapse {{ if $isActive }}show{{ end }}">
+        {{ range $item.children }}
+            {{ partial "theme/docs/components/sidenav/page.html" (dict
+                "page_context" $page
+                "item_context" .
+            ) }}
+        {{ end }}
+    </ul>
+</li>

--- a/layouts/_partials/theme/docs/components/sidenav/mobile-header.html
+++ b/layouts/_partials/theme/docs/components/sidenav/mobile-header.html
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<div class="mobile-sidenav-header">
+    <div class="icon-wrapper">
+        <button class="close-icon-button" id="close-mobile-sidenav">
+            <i class="close-icon"></i>
+        </button>
+    </div>
+</div>

--- a/layouts/_partials/theme/docs/components/sidenav/mobile-toggle.html
+++ b/layouts/_partials/theme/docs/components/sidenav/mobile-toggle.html
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<div id="mobile-sidenav-toggle">
+    <i class="fas fa-list-ul"></i>
+    <span>Contents</span>
+</div>

--- a/layouts/_partials/theme/docs/components/sidenav/page.html
+++ b/layouts/_partials/theme/docs/components/sidenav/page.html
@@ -1,0 +1,64 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $page := .page_context }}
+{{ $item := .item_context }}
+
+{{ $currentURL := $page.RelPermalink }}
+{{ $currentVersion := partial "theme/functions/get-doc-version.html" $page }}
+
+{{ if or $item.file_path (eq $item.file_path "") }}
+    {{ $filePath := printf "docs/%s/%s" $currentVersion.short $item.file_path }}
+    {{ with site.GetPage $filePath }}
+        <li>
+            {{ $pageURL := .RelPermalink }}
+            {{ $isActive := eq $currentURL $pageURL }}
+            <a class="sidenav-link {{ if $isActive }}active{{ end }}"
+               href="{{ $pageURL }}">
+                {{ $item.page }}
+            </a>
+        </li>
+    {{ end }}
+{{ else if $item.url }}
+    <li>
+        {{ $pageURL := $item.url }}
+        {{ $isExternalLink := partial "theme/functions/is-external-link.html" $pageURL }}
+        {{ if $isExternalLink }}
+            <a class="sidenav-link external-link"
+               href="{{ $pageURL }}"
+               target="_blank"
+               rel="nofollow noopener">
+                {{ $item.page }}
+            </a>
+        {{ else}}
+            {{ $isActive := eq $currentURL $pageURL }}
+            <a class="sidenav-link {{ if $isActive }}active{{ end }}"
+               href="{{ $pageURL | relURL }}">
+                {{ $item.page }}
+            </a>
+        {{ end }}
+    </li>
+{{ end }}

--- a/layouts/_partials/theme/docs/components/sidenav/section.html
+++ b/layouts/_partials/theme/docs/components/sidenav/section.html
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $page := .page_context }}
+{{ $item := .item_context }}
+
+{{ $currentSection := partial "theme/functions/get-doc-section.html" $page }}
+{{ $sectionKey := $item.key }}
+{{ $id := print $sectionKey "-section" }}
+{{ $isActive := eq $currentSection $sectionKey }}
+
+<li>
+    <span class="sidenav-link tree-title {{ if not $isActive }}collapsed{{ end }}"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ $id }}"
+          aria-controls="{{ $id }}"
+          aria-expanded="{{ $isActive }}">
+        {{ $item.page }}
+    </span>
+    <ul id="{{ $id }}" class="subnav collapse {{ if $isActive }}show{{ end }}">
+        {{ range $item.children }}
+            {{ if .children }}
+                {{ partial "theme/docs/components/sidenav/category.html" (dict
+                    "page_context" $page
+                    "item_context" .
+                ) }}
+            {{ else }}
+                {{ partial "theme/docs/components/sidenav/page.html" (dict
+                    "page_context" $page
+                    "item_context" .
+                ) }}
+            {{ end }}
+        {{ end }}
+    </ul>
+</li>

--- a/layouts/_partials/theme/docs/components/sidenav/sidenav.html
+++ b/layouts/_partials/theme/docs/components/sidenav/sidenav.html
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+{{ $page := . }}
+{{ $currentURL := .RelPermalink }}
+{{ $currentVersion := partial "theme/functions/get-doc-version.html" $page }}
+{{ $sidenavData := index site.Data.docs $currentVersion.short }}
+
+{{ if $sidenavData }}
+    {{ if $sidenavData.sidenav }}
+        {{ partial "theme/docs/components/sidenav/mobile-header.html" . }}
+        <ul class="doc-sidenav set-max-height">
+            {{ range $sidenavData.sidenav }}
+                {{ if .children }}
+                    {{ partial "theme/docs/components/sidenav/section.html" (dict
+                        "page_context" $page
+                        "item_context" .
+                    ) }}
+                {{ else }}
+                    {{ partial "theme/docs/components/sidenav/page.html" (dict
+                        "page_context" $page
+                        "item_context" .
+                    ) }}
+                {{ end }}
+            {{ end }}
+        </ul>
+    {{ end }}
+{{ end }}

--- a/layouts/_partials/theme/docs/layout/three-column.html
+++ b/layouts/_partials/theme/docs/layout/three-column.html
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<div class="page-content">
+    <div class="content-holder">
+        <div class="content-columns three-column">
+            {{ partial "theme/docs/components/sidenav/mobile-toggle.html" }}
+            <div class="doc-sidenav-col sticky-col mobile-sidenav-holder">
+                {{ partial "theme/docs/components/sidenav/sidenav.html" . }}
+            </div>
+            <div class="content-col markdown">
+                <div class="article-container article-text">
+                    {{ .Content }}
+                    {{ partial "theme/docs/components/bottom-nav/next-prev-nav.html" . }}
+                </div>
+            </div>
+            <div class="toc-col sticky-col">
+                <div class="set-max-height">
+                    <div class="interactive-toc">
+                        <div class="toc-indicator"></div>
+                        {{ .TableOfContents }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/layouts/_partials/theme/functions/get-doc-category.html
+++ b/layouts/_partials/theme/functions/get-doc-category.html
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns the parent directory name of the documentation file.
+
+In `docs/1/guides/installation/zip/` -> the category will be `installation`.
+-->
+
+{{ $filePath := "" }}
+{{ if $.File }}
+    {{ $filePath = .File.Path }}
+{{ end }}
+{{ $pathDir := path.Dir $filePath }}
+{{ $pathBase := path.Base $pathDir }}
+{{ return $pathBase }}

--- a/layouts/_partials/theme/functions/get-doc-link.html
+++ b/layouts/_partials/theme/functions/get-doc-link.html
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns the versioned documentation link according to the current page version.
+
+For example, the link `docs/guides/requirements/` will be returned as:
+- `docs/guides/requirements/` for the main documentation;
+- `docs/1/guides/requirements/` for the documentation version 1;
+- and so on.
+
+Adds the current version path only for links starting from `docs/...`.
+-->
+
+{{ $link := .link }}
+{{ $pageContext := .page }}
+
+{{ $currentVersion := partial "theme/functions/get-doc-version.html" $pageContext }}
+{{ if and (findRE `^/?docs/[^0-9][^ ]*` $link) (not (findRE `^/?docs/[0-9]+(/|$)` $link)) }}
+    {{ $link = replaceRE "docs" $currentVersion.path $link }}
+{{ end -}}
+
+{{ $link = $link | relURL }}
+{{ return $link }}

--- a/layouts/_partials/theme/functions/get-doc-section.html
+++ b/layouts/_partials/theme/functions/get-doc-section.html
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns the main section of the documentation file, located after the version.
+Needed to get the corresponding sidenav items.
+
+In `docs/1/guides/installation/zip/` -> the section will be `guides`.
+-->
+
+{{ $segments := slice }}
+{{ if $.File }}
+    {{ $segments = split .File.Path "/" }}
+{{ end }}
+{{ $section := index $segments 2 }}
+{{ return $section }}

--- a/layouts/_partials/theme/functions/get-doc-version.html
+++ b/layouts/_partials/theme/functions/get-doc-version.html
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns {Object} version item of the current page.
+For available item fields see `data/versions.yml`.
+
+If the version is undefined, returns the main version.
+This is useful for displaying the latest documentation navigation
+for pages like Release Notes, Roadmap, etc.
+-->
+
+{{ $versions := site.Data.versions }}
+{{ $mainVersion := index (where $versions "is_main" true) 0 }}
+{{ $currentPath := "" }}
+{{ with $.Page.File }}
+    {{ $currentPath = .Path }}
+{{ end }}
+{{ $currentVersion := "" }}
+{{ range $versions }}
+    {{ if in $currentPath (printf "docs/%s/" .short) }}
+        {{ $currentVersion = . }}
+    {{ end }}
+{{ end }}
+{{ if not $currentVersion }}
+    {{ $currentVersion = $mainVersion }}
+{{ end }}
+{{ return $currentVersion }}

--- a/layouts/_partials/theme/functions/get-full-version-name.html
+++ b/layouts/_partials/theme/functions/get-full-version-name.html
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+Returns the full version name.
+
+Translates the `full_i18n_key` property if it exists,
+otherwise returns the `full` property as it was set.
+-->
+{{ $currentVersion := . }}
+{{ $fullName := "" }}
+{{ if $currentVersion.full_i18n_key }}
+    {{ $fullName = i18n $currentVersion.full_i18n_key }}
+{{ else }}
+    {{ $fullName = $currentVersion.full }}
+{{ end }}
+{{ return $fullName }}

--- a/layouts/_shortcodes/docs-category-card.html
+++ b/layouts/_shortcodes/docs-category-card.html
@@ -14,7 +14,7 @@ Parameters:
 {{ $url := .Get "url" }}
 {{ $class := .Get "class" }}
 
-{{ $url = partial "functions/get-doc-link.html" (dict
+{{ $url = partial "theme/functions/get-doc-link.html" (dict
     "link" $url
     "page" .Page
 ) }}

--- a/layouts/_shortcodes/version.html
+++ b/layouts/_shortcodes/version.html
@@ -1,0 +1,19 @@
+{{- /*
+Returns the current documentation full version name
+or the full name of the provided version.
+
+Usage:
+{{< version >}} -> 1.9.0
+{{< version "2" >}} -> 2.0.0
+*/ -}}
+
+{{- $wantedVersion := .Get 0 -}}
+{{- $versions := site.Data.versions -}}
+{{- $currentVersion := partial "functions/get-doc-version.html" . -}}
+{{- $versionFullName := $currentVersion.full -}}
+{{- if $wantedVersion -}}
+    {{- $version := index (where $versions "short" $wantedVersion) 0 -}}
+    {{- $versionFullName = $version.full -}}
+{{- end -}}
+{{- $versionFullName -}}
+{{- /* Strip trailing newline. */ -}}

--- a/layouts/docs/full-screen.html
+++ b/layouts/docs/full-screen.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+    {{ .Content }}
+{{ end }}

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+    {{ partial "theme/docs/layout/three-column.html" . }}
+{{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+    {{ partial "theme/docs/layout/three-column.html" . }}
+{{ end }}


### PR DESCRIPTION
This PR brings the common layouts and functions to render the documentation pages:
- The `sidenav` component.
- The bottom navigation component.
- The helper functions to manage versions.
- Global markups to render images and links from markdown.