### PR TITLE
Resolve the relative Markdown URLs and add UI improvements

### DIFF
--- a/assets/scss/theme/components/sidenav/_sidenav.scss
+++ b/assets/scss/theme/components/sidenav/_sidenav.scss
@@ -129,6 +129,19 @@ $sidenav-chevron-active-border: $sidenav-chevron-border-size solid var(--sidenav
       color: var(--sidenav-link-active-color);
       font-weight: 600;
     }
+
+    /* Prevents the text from shifting when it becomes bold on active. */
+    &:after {
+      position: absolute;
+      content: attr(data-text);
+      font-weight: 600;
+      visibility: hidden;
+    }
+
+    code {
+      background-color: rgba(0, 0, 0, .05);
+      padding: 1px 3px 3px;
+    }
   }
 
   // Second level.

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -9,6 +9,10 @@
 {{- if or $isAbsolute $isSamePageAnchor -}}
     {{- $link = $link | safeURL -}}
 {{- else if (not $isMailto) }}
+    {{- $link = partial "theme/functions/resolve-relative-link.html" (dict
+        "link" $link
+        "page" .Page
+    ) -}}
     {{- $link = partial "theme/functions/get-doc-link.html" (dict
         "link" $link
         "page" .Page

--- a/layouts/_partials/theme/components/toc.html
+++ b/layouts/_partials/theme/components/toc.html
@@ -24,20 +24,23 @@
   ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 
-<div class="page-content">
-    <div class="content-holder">
-        <div class="content-columns three-column">
-            {{ partial "theme/docs/components/sidenav/mobile-toggle.html" }}
-            <div class="doc-sidenav-col sticky-col mobile-sidenav-holder">
-                {{ partial "theme/docs/components/sidenav/sidenav.html" . }}
+<!--
+  Displays the Table of Contents (TOC) column when there is more than one
+  TOC entry and the front-matter does not include `hide_toc: true`.
+-->
+
+{{ $context := . }}
+
+{{ $content := $context.TableOfContents }}
+{{ $items := findRE "<li" $content }}
+{{ $showToc := not .Params.hide_toc }}
+
+{{ if and $showToc (gt (len $items) 1) }}
+    <div class="toc-col sticky-col">
+        <div class="set-max-height">
+            <div class="interactive-toc">
+                {{ .TableOfContents }}
             </div>
-            <div class="content-col markdown">
-                <div class="article-container article-text">
-                    {{ .Content }}
-                    {{ partial "theme/docs/components/bottom-nav/next-prev-nav.html" . }}
-                </div>
-            </div>
-            {{ partial "theme/components/toc.html" . }}
         </div>
     </div>
-</div>
+{{ end }}

--- a/layouts/_partials/theme/docs/components/sidenav/page.html
+++ b/layouts/_partials/theme/docs/components/sidenav/page.html
@@ -37,7 +37,7 @@
             {{ $isActive := eq $currentURL $pageURL }}
             <a class="sidenav-link {{ if $isActive }}active{{ end }}"
                href="{{ $pageURL }}">
-                {{ $item.page }}
+                {{ $item.page | markdownify }}
             </a>
         </li>
     {{ end }}
@@ -50,13 +50,13 @@
                href="{{ $pageURL }}"
                target="_blank"
                rel="nofollow noopener">
-                {{ $item.page }}
+                {{ $item.page | markdownify }}
             </a>
         {{ else}}
             {{ $isActive := eq $currentURL $pageURL }}
             <a class="sidenav-link {{ if $isActive }}active{{ end }}"
                href="{{ $pageURL | relURL }}">
-                {{ $item.page }}
+                {{ $item.page | markdownify }}
             </a>
         {{ end }}
     </li>

--- a/layouts/_partials/theme/functions/get-doc-link.html
+++ b/layouts/_partials/theme/functions/get-doc-link.html
@@ -68,7 +68,9 @@
 {{ $versionedPattern := printf `^/?%s/[0-9]+([.-][0-9]+)*(/|$)` $moduleBase }}
 
 {{ $isModule := findRE $modulePattern $link }}
+{{ $hasExplicitVersion := in $link (printf "/%s/" $currentVersion.version_id) }}
 {{ $isVersioned := findRE $versionedPattern $link }}
+{{ $isVersioned = or $isVersioned $hasExplicitVersion }}
 
 {{ $isOtherModule := false }}
 {{ if eq $currentModule "docs" }}

--- a/layouts/_partials/theme/functions/resolve-relative-link.html
+++ b/layouts/_partials/theme/functions/resolve-relative-link.html
@@ -1,0 +1,60 @@
+<!--
+  ~ Copyright 2026, TeamDev. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!--
+  Resolves the Markdown relative links.
+
+  A link can be provided as:
+  * `file.md` – same folder
+  * `./file.md` – same folder (explicit)
+  * `folder/file.md` – subfolder
+  * `../file.md` – one level up
+  * `../../file.md` – two levels up
+  * `folder/` – folder index file
+  * `file.md#heading` – anchor in another file
+-->
+
+{{ $link := .link }}
+{{ $page := .page }}
+
+{{ $fragment := "" }}
+{{ $resolved := $link }}
+
+{{ $currentPageDir := $page.File.Dir }}
+{{ $parsedLink := urls.Parse $link }}
+{{ $destinationPath := $parsedLink.Path }}
+
+{{ with $parsedLink.Fragment }}
+    {{ $fragment = printf "#%s" . }}
+{{ end }}
+
+{{ $destinationPath = path.Clean (path.Join $currentPageDir $destinationPath) }}
+
+{{ with site.GetPage $destinationPath }}
+    {{ $resolved = printf "%s%s" .RelPermalink $fragment }}
+{{ end }}
+
+{{ return $resolved }}


### PR DESCRIPTION
This PR makes it possible to resolve the relative Markdown URLs, such us:
- `file.md` – same folder
- `./file.md` – same folder (explicit)
- `folder/file.md` – subfolder
- `../file.md` – one level up
- `../../file.md` – two levels up
- `folder/` – folder index file
- `file.md#heading` – anchor in another file

### Other changes

- Improved the sidenav item style if it has the `code` element:
  <img width="208" height="122" alt="image" src="https://github.com/user-attachments/assets/faf4c240-c5f1-46f2-b0a7-c58799ebba17" />

- Avoid text jumping when the item becomes active.
- The TOC will not be shown if it has only one link item.
