### PR TITLE
Fix styles of the bottom navigation

### DIFF
--- a/assets/scss/theme/common/_typography.scss
+++ b/assets/scss/theme/common/_typography.scss
@@ -110,6 +110,7 @@ a {
   &:focus {
     color: $link-hover-color;
     text-decoration: underline;
+    text-underline-offset: 2px;
   }
 }
 

--- a/assets/scss/theme/components/_next-prev-nav.scss
+++ b/assets/scss/theme/components/_next-prev-nav.scss
@@ -53,6 +53,7 @@
   .arrow-link {
     display: flex;
     align-items: center;
+    line-height: 1.5;
 
     &:after,
     &:before {

--- a/layouts/_partials/theme/docs/components/bottom-nav/next-prev-nav.html
+++ b/layouts/_partials/theme/docs/components/bottom-nav/next-prev-nav.html
@@ -42,7 +42,7 @@
             <div class="item previous">
                 <a class="arrow-link prev"
                    href="{{ $prev.url | relURL }}">
-                    <span>{{ $prev.title }}</span>
+                    <span>{{ $prev.title | markdownify }}</span>
                 </a>
             </div>
         {{ end }}
@@ -51,7 +51,7 @@
             <div class="item next">
                 <a class="arrow-link next"
                    href="{{ $next.url | relURL }}">
-                    <span>{{ $next.title }}</span>
+                    <span>{{ $next.title | markdownify }}</span>
                 </a>
             </div>
         {{ end }}


### PR DESCRIPTION
This PR fixes #24.

This PR fixes the `<code>` element styles in the bottom navigation links:

<img width="668" height="57" alt="Screenshot 2026-05-06 at 11 27 47" src="https://github.com/user-attachments/assets/6fa6cc32-f9bb-4a36-9d7d-fe4ef0cb13a0" />
