### PR TITLE
Improve the sidebar navigation logic

### DIFF
--- a/layouts/_partials/theme/functions/get-doc-section.html
+++ b/layouts/_partials/theme/functions/get-doc-section.html
@@ -25,24 +25,48 @@
   -->
 
 <!--
-  Returns the main section of the documentation file, located after the version.
-  Needed to get the corresponding sidenav items.
+  Returns the section of the documentation file used to match sidenav entries.
 
-  In `docs/1/guides/installation/zip/` -> the section will be `guides`.
-  If no version `docs/guides/installation/zip/` -> the section will be `guides`.
+  Finds the longest matching `content_path` from `data/versions.yml` and returns
+  the first path segment after that prefix:
+    `docs/validation/user/00-intro/` -> section is `user`.
+    `docs/validation/developer/architecture` -> section is `developer`.
+
+  Falls back to the original logic for pages outside any versioned content path:
+    `docs/1/guides/installation/zip/` -> section is `guides`.
+    `docs/guides/installation/zip/` -> section is `guides`.
 -->
 
-{{ $segments := slice }}
-{{ $section := "" }}
-
+{{ $filePath := "" }}
 {{ if $.File }}
-    {{ $segments = split .File.Path "/" }}
+    {{ $filePath = .File.Path }}
 {{ end }}
 
-{{ if and (ge (len $segments) 3) (findRE `^\d+$` (index $segments 1)) }}
-    {{ $section = index $segments 2 }}
-{{ else }}
-    {{ $section = index $segments 1 }}
+{{ $section := "" }}
+{{ $bestMatchLen := 0 }}
+
+{{ range $moduleName, $versions := site.Data.versions }}
+    {{ range $versions }}
+        {{ $prefix := print .content_path "/" }}
+        {{ if strings.HasPrefix $filePath $prefix }}
+            {{ $matchLen := len .content_path }}
+            {{ if gt $matchLen $bestMatchLen }}
+                {{ $bestMatchLen = $matchLen }}
+                {{ $rest := strings.TrimPrefix $prefix $filePath }}
+                {{ $section = index (split $rest "/") 0 }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{/* Fallback: original logic for pages outside any versioned content path. */}}
+{{ if not $section }}
+    {{ $segments := split $filePath "/" }}
+    {{ if and (ge (len $segments) 3) (findRE `^\d+$` (index $segments 1)) }}
+        {{ $section = index $segments 2 }}
+    {{ else }}
+        {{ $section = index $segments 1 }}
+    {{ end }}
 {{ end }}
 
 {{ return $section }}


### PR DESCRIPTION
This PR addresses [comment #293](https://github.com/SpineEventEngine/validation/pull/293#discussion_r3197108363) and brings the improved logic that returns the current documentation root section.

It is useful for the case when the `developer` and `user` sections should appear as top-level items in the side navigation.

<img width="179" height="194" alt="image" src="https://github.com/user-attachments/assets/97467d99-9817-49f1-b31b-d0ced20516c1" />
