### PR TITLE
Avoid premature text wrapping in page navigation

### DIFF
--- a/assets/scss/theme/common/_layout.scss
+++ b/assets/scss/theme/common/_layout.scss
@@ -107,6 +107,15 @@ $layout-padding-phone: 20px;
   }
 }
 
+.toc-col {
+  width: calc(50vw - (760px / 2));
+  max-width: 500px;
+
+  @include breakpoint($layout-max-width) {
+    width: auto;
+  }
+}
+
 .sticky-col {
   position: sticky;
   align-self: start;


### PR DESCRIPTION
This PR fixes #27.

This PR makes the TOC element full width until it is enough space to prevent the premature text wrapping.

https://github.com/user-attachments/assets/caf48975-cb75-48e3-84ab-7f3f067b5f22

