### PR TITLE
Update Hugo version to `0.161.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It provides:
 ## Prerequisites
 
 1. [Go][go] `1.12` or newer.
-2. [Hugo Extended][hugo-quick-start] in version `v0.150.0` or higher.
+2. [Hugo Extended][hugo-quick-start] in version `v0.161.1` or higher.
 
 ## Installation
 

--- a/layouts/_partials/theme/docs/components/sidenav/functions/get-docs-sidenav.html
+++ b/layouts/_partials/theme/docs/components/sidenav/functions/get-docs-sidenav.html
@@ -33,7 +33,7 @@
 -->
 
 {{ $page := . }}
-{{ $docsData := site.Data.docs }}
+{{ $docsData := hugo.Data.docs }}
 {{ $sidenavData := slice }}
 
 {{ $docsVersion := partial "theme/functions/get-doc-module-version.html" (dict

--- a/layouts/_partials/theme/docs/components/sidenav/functions/get-module-sidenav.html
+++ b/layouts/_partials/theme/docs/components/sidenav/functions/get-module-sidenav.html
@@ -35,7 +35,7 @@
 -->
 
 {{ $page := . }}
-{{ $docsData := site.Data.docs }}
+{{ $docsData := hugo.Data.docs }}
 {{ $sidenavData := slice }}
 {{ $orderedModules := partial "theme/docs/components/sidenav/functions/get-ordered-modules.html" $docsData }}
 

--- a/layouts/_partials/theme/functions/get-doc-link.html
+++ b/layouts/_partials/theme/functions/get-doc-link.html
@@ -54,7 +54,7 @@
 {{ $pageContext := .page }}
 
 {{ $modules := slice }}
-{{ $versions := site.Data.versions | default (slice) }}
+{{ $versions := hugo.Data.versions | default (slice) }}
 {{ range $module, $items := $versions }}
     {{ $modules = $modules | append $module }}
 {{ end }}

--- a/layouts/_partials/theme/functions/get-doc-module-version.html
+++ b/layouts/_partials/theme/functions/get-doc-module-version.html
@@ -44,7 +44,7 @@
 {{ end }}
 
 {{ $version := "" }}
-{{ $versions := index site.Data.versions $module | default (slice) }}
+{{ $versions := index hugo.Data.versions $module | default (slice) }}
 {{ $mainVersion := index (where $versions "is_main" true) 0 }}
 
 {{ range $versions }}

--- a/layouts/_partials/theme/functions/get-doc-section.html
+++ b/layouts/_partials/theme/functions/get-doc-section.html
@@ -45,7 +45,7 @@
 {{ $section := "" }}
 {{ $bestMatchLen := 0 }}
 
-{{ range $moduleName, $versions := site.Data.versions }}
+{{ range $moduleName, $versions := hugo.Data.versions }}
     {{ range $versions }}
         {{ $prefix := print .content_path "/" }}
         {{ if strings.HasPrefix $filePath $prefix }}

--- a/layouts/_partials/theme/functions/get-doc-version-data.html
+++ b/layouts/_partials/theme/functions/get-doc-version-data.html
@@ -38,7 +38,7 @@
 
 {{ $result := dict "version" dict "module" "" }}
 
-{{ $versions := site.Data.versions | default (slice) }}
+{{ $versions := hugo.Data.versions | default (slice) }}
 {{ range $module, $items := $versions }}
     {{ range $items }}
         {{ if strings.Contains $currentPath .content_path }}

--- a/layouts/_partials/theme/functions/whitelist-checker.html
+++ b/layouts/_partials/theme/functions/whitelist-checker.html
@@ -30,7 +30,7 @@ and should not receive the `rel="nofollow"` property.
 -->
 
 {{ $url := . }}
-{{ $whitelist := site.Data.whitelist.domains }}
+{{ $whitelist := hugo.Data.whitelist.domains }}
 {{ $skipNofollow := false }}
 {{ if and $url (hasPrefix $url "http") }}
     {{ range $whitelist }}

--- a/layouts/_shortcodes/cloakemail.html
+++ b/layouts/_shortcodes/cloakemail.html
@@ -5,7 +5,7 @@
 {{- $displayParam := .Get "display" | default (.Get 0) -}}
 {{- $displaytext := "" -}}
 {{- if $displayVariable -}}
-{{- $displaytext = index site.Data (split $displayVariable ".") -}}
+{{- $displaytext = index hugo.Data (split $displayVariable ".") -}}
 {{- else -}}
 {{- $displaytext = $displayParam -}}
 {{- end -}}
@@ -15,7 +15,7 @@
 {{- $addressParam := .Get "address" | default (.Get 0) -}}
 {{- $address := "" -}}
 {{- if $addressVariable -}}
-{{- $address = index site.Data (split $addressVariable ".") -}}
+{{- $address = index hugo.Data (split $addressVariable ".") -}}
 {{- else -}}
 {{- $address = $addressParam -}}
 {{- end -}}

--- a/layouts/_shortcodes/get-site-data.html
+++ b/layouts/_shortcodes/get-site-data.html
@@ -8,7 +8,7 @@ from the `data/emails.yml` file.
 
 {{- $dataPath := .Get 0 -}}
 {{- with split $dataPath "." -}}
-    {{- $data := site.Data -}}
+    {{- $data := hugo.Data -}}
     {{- range . -}}
         {{- $data = index $data . -}}
     {{- end -}}

--- a/layouts/_shortcodes/version.html
+++ b/layouts/_shortcodes/version.html
@@ -11,7 +11,7 @@ Usage:
 {{- $versionData := partial "theme/functions/get-doc-version-data.html" . -}}
 {{- $versionFullName := $versionData.version.label -}}
 {{- if $wantedVersion -}}
-    {{- $versions := index site.Data.versions $versionData.module | default (slice) -}}
+    {{- $versions := index hugo.Data.versions $versionData.module | default (slice) -}}
     {{- $version := where $versions "short" $wantedVersion -}}
     {{- $version = cond (gt (len $version) 0) (index $version 0) dict -}}
     {{- $versionFullName = $version.label -}}


### PR DESCRIPTION
This PR addresses [#541](https://github.com/SpineEventEngine/SpineEventEngine.github.io/issues/541).

This PR updates deprecated parameters to ensure the site runs on Hugo `0.161.1`.